### PR TITLE
Initial mesh FBX export using ModTools build

### DIFF
--- a/ProceduralOverpassWalls/Classes/ProceduralClasses.cs
+++ b/ProceduralOverpassWalls/Classes/ProceduralClasses.cs
@@ -591,6 +591,7 @@ namespace ProceduralObjects.Classes
         {
             renderDistance = sourceObj.renderDistance;
             renderDistLocked = sourceObj.renderDistLocked;
+            mesh = sourceObj.m_mesh;
             if (sourceObj.meshStatus == 2)
             {
                 allVertices = sourceObj.m_mesh.vertices;
@@ -649,6 +650,7 @@ namespace ProceduralObjects.Classes
         public ProceduralObjectVisibility visibility;
         public NormalsRecalculation normalsRecalculation;
         public TextParameters textParam;
+        public Mesh mesh;
     }
     
     public class ProceduralInfo

--- a/ProceduralOverpassWalls/ProceduralObjectsMod.cs
+++ b/ProceduralOverpassWalls/ProceduralObjectsMod.cs
@@ -110,7 +110,9 @@ namespace ProceduralObjects
                 var subItems = PlatformService.workshop.GetSubscribedItems();
                 if (subItems.Length > 0)
                 {
-                    List<string> paths = new List<string>();
+                    List<string> paths = (Directory.GetDirectories(DataLocation.addonsPath)
+                                            .Concat(Directory.GetDirectories(DataLocation.gameContentPath + (ProceduralObjectsMod.IsLinux ? "/" : @"\") + "Mods")))
+                                            .ToList();
                     foreach (PublishedFileId fileId in subItems)
                     {
                         string path = PlatformService.workshop.GetSubscribedItemPath(fileId);

--- a/ProceduralOverpassWalls/SelectionMode/ExportSelection.cs
+++ b/ProceduralOverpassWalls/SelectionMode/ExportSelection.cs
@@ -10,6 +10,12 @@ namespace ProceduralObjects.SelectionMode
 {
     public class ExportSelection : SelectionModeAction
     {
+        public enum ExportMode
+        {
+            Ploppable = 0,
+            StaticImport = 1,
+            FBX = 3
+        }
         public ClipboardProceduralObjects clipboard;
 
         public override void OnOpen(List<ProceduralObject> selection)
@@ -31,19 +37,25 @@ namespace ProceduralObjects.SelectionMode
         }
         public override void OnActionGUI(Vector2 uiPos)
         {
-            if (GUI.Button(new Rect(uiPos, new Vector2(180, 22)), LocalizationManager.instance.current["export_as_ploppable"]))
+            if (GUI.Button(new Rect(uiPos, new Vector2(180, 22)), LocalizationManager.instance.current["export_as_fbx"]))
             {
                 ProceduralObjectsLogic.PlaySound();
-                clipboard.ExportSelection("Selection " + DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss"), logic.ExPObjManager, false);
+                clipboard.ExportSelection("Selection " + DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss"), logic.ExPObjManager, ExportMode.FBX);
                 ExitAction();
             }
-            if (GUI.Button(new Rect(uiPos.x, uiPos.y + 23, 180, 22), LocalizationManager.instance.current["export_as_fixed"]))
+            if (GUI.Button(new Rect(uiPos.x, uiPos.y + 23, 180, 22), LocalizationManager.instance.current["export_as_ploppable"]))
             {
                 ProceduralObjectsLogic.PlaySound();
-                clipboard.ExportSelection("Fixed Export " + DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss"), logic.ExPObjManager, true);
+                clipboard.ExportSelection("Selection " + DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss"), logic.ExPObjManager, ExportMode.Ploppable);
                 ExitAction();
             }
-            if (GUI.Button(new Rect(uiPos.x, uiPos.y + 46, 180, 22), LocalizationManager.instance.current["cancel"]))
+            if (GUI.Button(new Rect(uiPos.x, uiPos.y + 46, 180, 22), LocalizationManager.instance.current["export_as_fixed"]))
+            {
+                ProceduralObjectsLogic.PlaySound();
+                clipboard.ExportSelection("Fixed Export " + DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss"), logic.ExPObjManager, ExportMode.StaticImport);
+                ExitAction();
+            }
+            if (GUI.Button(new Rect(uiPos.x, uiPos.y + 69, 180, 22), LocalizationManager.instance.current["cancel"]))
             {
                 ProceduralObjectsLogic.PlaySound();
                 ExitAction();


### PR DESCRIPTION
If the user has modtools loaded in, selecting the option will allow them to export the selection as ASCII fbx files that (with some changes) can be loaded into blender and cleaned up to create a single asset.

There is still some work that should be done to make this really good, like not showing the export option if modtools is not there (currently only checking when actually exporting, but it is done safely to not lose the data). I think also getting the relative position in the meshes being exported would be good so that you can just import them all into blender and each mesh would already be in position (I don't think it does that currently).